### PR TITLE
Beta: drop appstream-compose command

### DIFF
--- a/org.kicad.KiCad.ODBCDriver.psqlodbc.yml
+++ b/org.kicad.KiCad.ODBCDriver.psqlodbc.yml
@@ -51,12 +51,6 @@ modules:
       - >
         install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo \
           org.kicad.KiCad.ODBCDriver.psqlodbc.metainfo.xml
-      - >
-        appstream-compose \
-          --basename=org.kicad.KiCad.ODBCDriver.psqlodbc \
-          --prefix=${FLATPAK_DEST} \
-          --origin=flatpak \
-            org.kicad.KiCad.ODBCDriver.psqlodbc
     sources:
       - type: git
         url: https://git.postgresql.org/git/psqlodbc.git


### PR DESCRIPTION
This is done in preparation for FDO SDK 24.08, which will not provide this command anymore. Also according to official docs:

> Flatpak-builder (>= 1.3.4), can compose metadata for extensions
> automatically and it is no longer required to manually compose them
> through commands in the manifest.

(https://docs.flatpak.org/en/latest/extension.html#extension-manifest)